### PR TITLE
suppress WHERE {} fixes #2

### DIFF
--- a/samples/pivot-table.html
+++ b/samples/pivot-table.html
@@ -928,7 +928,9 @@
                         }
                         mdx += "\nFROM [" + node.cube + "]";
                         axis = axes["SlicerAxis"];
-                        if (axis){
+                        // filtering out empty slicer to avoid WHERE {} when mondrian sends
+                        // <Axis name="SlicerAxis"> <Tuples> <Tuple/> </Tuples> </Axis>
+                        if (axis && !(axis.tuples[0].members.length==0 && axis.tuples.length==1)){
                             mdx += "\nWHERE " + getMDX(axis);
                         }
                         break;


### PR DESCRIPTION
hello,

when I click Render Table mondrian sends empty slicer  axis <Axis name="SlicerAxis"> <Tuples> <Tuple/> </Tuples> </Axis> due to https://github.com/pentaho/mondrian/commit/88be25c4d9ed0f61035ae734193916be4abbdb72#L57R1995 , then xmla4j forms empty WHERE {} clause, when it sends back on drill down mondrian falls with 

Caused by: java.lang.NullPointerException
at mondrian.xmla.XmlaHandler$MDDataSet_Multidimensional.writeHierarchyInfo(XmlaHandler.java:2039)
at mondrian.xmla.XmlaHandler$MDDataSet_Multidimensional.axisInfo(XmlaHandler.java:2025)
at mondrian.xmla.XmlaHandler$MDDataSet_Multidimensional.olapInfo(XmlaHandler.java:1937)
at mondrian.xmla.XmlaHandler$MDDataSet_Multidimensional.unparse(XmlaHandler.java:1901)
at mondrian.xmla.XmlaHandler.execute(XmlaHandler.java:800)
